### PR TITLE
Fix for #25708

### DIFF
--- a/ocpp1.6/types/types.go
+++ b/ocpp1.6/types/types.go
@@ -310,7 +310,7 @@ type SampledValue struct {
 
 type MeterValue struct {
 	Timestamp    *DateTime      `json:"timestamp" validate:"required"`
-	SampledValue []SampledValue `json:"sampledValue" validate:"required,min=1,dive"`
+	SampledValue []SampledValue `json:"sampledValue" validate:"required,dive"`
 }
 
 // Initialize validator


### PR DESCRIPTION
## Proposed changes

SonnenHome Charger 2 sends an invalid OCPP package on stoptransaction, because sampledValue is an empty list:

`[ocpp  ] ERROR 2025/11/30 19:17:20 ocpp message (<redacted>): PropertyConstraintViolation - Field Call.Payload.TransactionData[0].SampledValue must be minimum 1, but was 0 for feature StopTransaction ([2,"<redacted>","StopTransaction",{"meterStop":<redacted>,"timestamp":"2025-11-30T13:14:01Z","transactionId":<redacted>,"reason":"Local","idTag":"<redacted>","transactionData":[{"sampledValue":[],"timestamp":"2025-11-30T13:14:01Z"}]}])`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/xBlaz3kx/ocppManager-go/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
-