### PR TITLE
Fix client dispatcher deadlock on SendRequest during stop

### DIFF
--- a/ocppj/dispatcher.go
+++ b/ocppj/dispatcher.go
@@ -89,6 +89,7 @@ type DefaultClientDispatcher struct {
 	requestQueue        RequestQueue
 	requestChannel      chan bool
 	readyForDispatch    chan bool
+	stopped             chan struct{}
 	pendingRequestState ClientState
 	network             ws.Client
 	mutex               sync.RWMutex
@@ -126,6 +127,7 @@ func (d *DefaultClientDispatcher) Start() {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
 	d.requestChannel = make(chan bool, 1)
+	d.stopped = make(chan struct{})
 	d.timer = time.NewTimer(defaultTimeoutTick) // Default to 24 hours tick
 	go d.messagePump()
 }
@@ -145,6 +147,9 @@ func (d *DefaultClientDispatcher) IsPaused() bool {
 func (d *DefaultClientDispatcher) Stop() {
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
+	// signal stop before closing the request channel, so a concurrent
+	// SendRequest bails out instead of sending on the closed channel
+	close(d.stopped)
 	close(d.requestChannel)
 	// TODO: clear pending requests?
 }
@@ -158,15 +163,36 @@ func (d *DefaultClientDispatcher) SetPendingRequestState(state ClientState) {
 }
 
 func (d *DefaultClientDispatcher) SendRequest(req RequestBundle) error {
+	// Hold the read lock for the whole call: it is mutually exclusive with
+	// Stop's write lock, so requestChannel cannot be closed underneath us.
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
 	if d.network == nil {
 		return fmt.Errorf("cannot SendRequest, no network client was set")
+	}
+	if d.requestChannel == nil {
+		return fmt.Errorf("cannot SendRequest, dispatcher is not running")
+	}
+	// Bail out if the dispatcher is stopping, to avoid sending on the closed
+	// requestChannel once Stop has run.
+	select {
+	case <-d.stopped:
+		return fmt.Errorf("cannot SendRequest, dispatcher is stopped")
+	default:
 	}
 	if err := d.requestQueue.Push(req); err != nil {
 		return err
 	}
-	d.mutex.RLock()
-	d.requestChannel <- true
-	d.mutex.RUnlock()
+	// requestChannel is only a wake-up notification for the message pump; the
+	// request queued above is the source of truth. A non-blocking send is
+	// therefore sufficient: if a notification is already pending the pump will
+	// re-check the queue and pick up this request anyway. Blocking here used to
+	// deadlock teardown, because callers hold the callback-queue mutex while the
+	// pump had already stopped draining the channel.
+	select {
+	case d.requestChannel <- true:
+	default:
+	}
 	return nil
 }
 

--- a/ocppj/dispatcher_test.go
+++ b/ocppj/dispatcher_test.go
@@ -285,6 +285,33 @@ func (c *ClientDispatcherTestSuite) TestClientSendRequest() {
 
 }
 
+func (c *ClientDispatcherTestSuite) TestClientSendRequestAfterStop() {
+	t := c.T()
+	// Setup
+	c.dispatcher.Start()
+	require.True(t, c.dispatcher.IsRunning())
+	c.dispatcher.Stop()
+	// Create mock request
+	req := newMockRequest("somevalue")
+	call, err := c.endpoint.CreateCall(req)
+	require.NoError(t, err)
+	data, err := call.MarshalJSON()
+	require.NoError(t, err)
+	bundle := ocppj.RequestBundle{Call: call, Data: data}
+	// SendRequest after Stop must fail fast rather than panic on the closed
+	// notification channel or block forever once the message pump has exited.
+	done := make(chan error, 1)
+	go func() {
+		done <- c.dispatcher.SendRequest(bundle)
+	}()
+	select {
+	case err := <-done:
+		assert.Error(t, err)
+	case <-time.After(time.Second):
+		require.Fail(t, "SendRequest blocked after the dispatcher was stopped")
+	}
+}
+
 func (c *ClientDispatcherTestSuite) TestClientRequestCanceled() {
 	t := c.T()
 	// Setup


### PR DESCRIPTION
`DefaultClientDispatcher.SendRequest` does a blocking send on the `requestChannel` notification channel:

```go
d.mutex.RLock()
d.requestChannel <- true
d.mutex.RUnlock()
```

The caller chain holds the callback-queue mutex across this send (`chargePoint.SendRequestAsync` → `callbackqueue.TryQueue` holds `callbacksMutex.Lock()` while running `try()` → `SendRequest`). Once the message pump has stopped draining `requestChannel` (during/after teardown), this send blocks forever, so the callbacks mutex is never released and the concurrent `clearCallbacks` on stop (`asyncCallbackHandler` ← `<-stopC`) deadlocks on the same mutex. The send can also panic on a closed channel after `Stop`.

This surfaced as a 10-minute hang in a downstream test suite (charge point connect/send/stop cycling), with one goroutine blocked at `dispatcher.go` on `requestChannel <- true` while holding the callbacks mutex, and another blocked acquiring that mutex in `clearCallbacks`.

`requestChannel` is only a wake-up doorbell — the request enqueued in `requestQueue` is the source of truth, and the pump re-checks the queue on every wake (paced by `readyForDispatch`/responses, not one dispatch per doorbell). So a dropped doorbell is harmless. This change:

- makes the doorbell send non-blocking (`select { case d.requestChannel <- true: default: }`), so `SendRequest` never blocks;
- adds a `stopped` signal channel (mirroring the server dispatcher's `stoppedC`), and bails out of `SendRequest` when stopping to avoid sending on the closed channel;
- holds the read lock for the whole call (mutually exclusive with `Stop`'s write lock) so `requestChannel` cannot be closed mid-send.

Adds a regression test (`TestClientSendRequestAfterStop`) that blocks/fails without the fix and passes with it. Existing `./ocppj/...` suite stays green.